### PR TITLE
jekyll-sitemap v0.5.0 ist noch nicht auf GitHub Pages

### DIFF
--- a/_posts/2014-05-22-jekyll-sitemap-plugin-mit-github-pages.md
+++ b/_posts/2014-05-22-jekyll-sitemap-plugin-mit-github-pages.md
@@ -19,4 +19,4 @@ gems:
 
 Das Plugin steht auf der Whitelist und läuft somit auch mit bequemen Build-Prozess auf GitHub Pages. Spitze!
 
-Seit Version 0.5.0 kann man mit `sitemap: false` im Front Matter auch Seiten wie die 404.html ausschließen.
+Seit Version 0.5.0 (noch nicht auf GitHub Pages) kann man mit `sitemap: false` im Front Matter auch Seiten wie die 404.html ausschließen.


### PR DESCRIPTION
Schöne Seite, kleinfreund. Danke für die Hilfe bei Jekyll.

Leider liegt jekyll-sitemap auf GitHub Pages noch zu v0.3.0: https://pages.github.com/versions/

Tut mir Leid, ob mein Deutsch zu schlecht ist. Ich lerne noch :)
